### PR TITLE
Add license to gemspec

### DIFF
--- a/ipaddress.gemspec
+++ b/ipaddress.gemspec
@@ -41,6 +41,7 @@ Gem::Specification.new do |s|
     "test/test_helper.rb"
   ]
   s.homepage = %q{http://github.com/bluemonk/ipaddress}
+  s.license = 'MIT'
   s.require_paths = ["lib"]
   s.rubygems_version = %q{1.6.2}
   s.summary = %q{IPv4/IPv6 addresses manipulation library}


### PR DESCRIPTION
I was trying to determine the licenses for my dependencies. I found that the RubyGems API will return the license, but only if it is specified in your gemspec file.