### PR TITLE
Add IPv4#to_h

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -29,6 +29,8 @@ IPAddress 0.8.0 has been tested on:
 * jruby-1.6.1 [ linux-i386-java ]
 * ruby-1.9.1-p431 [ i386 ]
 * ruby-1.9.2-p180 [ i386 ]
+* ruby-2.0.0-p353 [ x86_64-darwin14.0.0 ]
+* ruby-2.1.3-p242 [ x86_64-darwin14.0.0 ]
 
 If you want to collaborate feel 
 free to send a small report to my email address, or 

--- a/README.rdoc
+++ b/README.rdoc
@@ -318,11 +318,16 @@ transform it in data format using the IPv4#data method:
   ip.data
     #=> "\254\020\n\001"
 
-Finally, you can transform an IPv4 address into a format which is
+Also, you can transform an IPv4 address into a format which is
 suitable to use in IPv4-IPv6 mapped addresses:
 
   ip.to_ipv6
     #=> "ac10:0a01"
+
+Finally, much like IPv4#to_ipv6 you can use to IPv4#to_h method to return a non-semicolon delineated string (useful with pcap/byte level usage):
+
+  ip.to_h
+    #=> "ac100a01"
 
 === Classful networks
 

--- a/lib/ipaddress/ipv4.rb
+++ b/lib/ipaddress/ipv4.rb
@@ -231,6 +231,22 @@ module IPAddress;
     alias_method :to_u32, :u32
     
     #
+    # Returns the address portion in 
+    # hex
+    #
+    #   ip = IPAddress("10.0.0.0")
+    #
+    #   ip.to_h
+    #     #=> 0a000000
+    #
+    def hex
+      hex = @octets.map{|o| o.to_s(16).rjust(2, '0') }.join()
+      "#{hex}"
+    end
+    alias_method :to_h, :hex
+    alias_method :to_hex, :hex   
+
+    #
     # Returns the address portion of an IPv4 object
     # in a network byte order format.
     #

--- a/lib/ipaddress/ipv4.rb
+++ b/lib/ipaddress/ipv4.rb
@@ -239,9 +239,8 @@ module IPAddress;
     #   ip.to_h
     #     #=> 0a000000
     #
-    def hex
-      hex = @octets.map{|o| o.to_s(16).rjust(2, '0') }.join()
-      "#{hex}"
+    def hex(space=true)
+      "%.4x%.4x" % [to_u32].pack("N").unpack("nn")
     end
     alias_method :to_h, :hex
     alias_method :to_hex, :hex   

--- a/test/ipaddress/ipv4_test.rb
+++ b/test/ipaddress/ipv4_test.rb
@@ -34,7 +34,13 @@ class IPv4Test < Test::Unit::TestCase
       "172.16.0.0/16"    => 2886729728,
       "192.168.0.0/24"   => 3232235520,
       "192.168.100.4/30" => 3232261124}
-    
+
+    @hex_values = {
+      "10.0.0.0"         => "0a000000",
+      "172.16.5.4"       => "ac100504",
+      "192.168.100.4"    => "c0a86404",
+    }
+
     @ip = @klass.new("172.16.10.1/24")
     @network = @klass.new("172.16.10.0/24")
     
@@ -141,6 +147,13 @@ class IPv4Test < Test::Unit::TestCase
     @decimal_values.each do |addr,int|
       ip = @klass.new(addr)
       assert_equal int, ip.to_u32
+    end
+  end
+
+  def test_method_to_hex
+    @hex_values.each do |addr,hex|
+      ip = @klass.new(addr)
+      assert_equal hex, ip.to_hex
     end
   end
 


### PR DESCRIPTION
Makes it easier to work with libpcap lib's without bloating code writing `IPv4#to_ipv6.gsub(/:/, '')`.

Added tests. Pretty much duplicates `to_ipv6` but removed the `:`.