### PR TITLE
Improve reverse IP handling

### DIFF
--- a/lib/ipaddress.rb
+++ b/lib/ipaddress.rb
@@ -28,7 +28,9 @@ module IPAddress
   #
   #   ip  = IPAddress.parse 167837953 # 10.1.1.1  
   #   ip  = IPAddress.parse "172.16.10.1/24"
+  #   ip  = IPAddress.parse "100.16.172.in-addr.arpa"
   #   ip6 = IPAddress.parse "2001:db8::8:800:200c:417a/64"
+  #   ip6 = IPAddress.parse "0.0.0.0.0.0.0.0.8.b.d.0.1.0.0.2.ip6.arpa"
   #   ip_mapped = IPAddress.parse "::ffff:172.16.10.1/128"
   #
   # All the object created will be instances of the 
@@ -40,6 +42,10 @@ module IPAddress
   #    #=> IPAddress::IPv6
   #  ip_mapped.class
   #    #=> IPAddress::IPv6::Mapped
+  #  ip_reverse.class
+  #    #=> IPAddress::IPv4
+  #  ip6_reverse.class
+  #    #=> IPAddress::IPv6
   #
   def IPAddress::parse(str)
     
@@ -49,6 +55,10 @@ module IPAddress
     end
 
     case str
+    when /\.in-addr.arpa$/
+      IPAddress::IPv4.from_reverse(str)
+    when /\.ip6.arpa$/
+      IPAddress::IPv6.from_reverse(str)
     when /:.+\./
       IPAddress::IPv6::Mapped.new(str)
     when /\./
@@ -151,6 +161,20 @@ module IPAddress
   end
   
   #
+  # Checks if the argument is a valid IPv4 reverse address
+  # expressed in arpa format.
+  #
+  #   IPAddress.valid_ipv4_reverse? "10.16.172.in-addr.arpa"
+  #     #=> true
+  #
+  def self.valid_ipv4_reverse?(addr)
+    IPAddress::IPv4.from_reverse(addr)
+    true
+  rescue
+    false
+  end
+  
+  #
   # Checks if the given string is a valid IPv6 address
   #
   # Example:
@@ -165,6 +189,20 @@ module IPAddress
     # https://gist.github.com/cpetschnig/294476
     # http://forums.intermapper.com/viewtopic.php?t=452
     return true if /^\s*((([0-9A-Fa-f]{1,4}:){7}([0-9A-Fa-f]{1,4}|:))|(([0-9A-Fa-f]{1,4}:){6}(:[0-9A-Fa-f]{1,4}|((25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3})|:))|(([0-9A-Fa-f]{1,4}:){5}(((:[0-9A-Fa-f]{1,4}){1,2})|:((25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3})|:))|(([0-9A-Fa-f]{1,4}:){4}(((:[0-9A-Fa-f]{1,4}){1,3})|((:[0-9A-Fa-f]{1,4})?:((25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3}))|:))|(([0-9A-Fa-f]{1,4}:){3}(((:[0-9A-Fa-f]{1,4}){1,4})|((:[0-9A-Fa-f]{1,4}){0,2}:((25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3}))|:))|(([0-9A-Fa-f]{1,4}:){2}(((:[0-9A-Fa-f]{1,4}){1,5})|((:[0-9A-Fa-f]{1,4}){0,3}:((25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3}))|:))|(([0-9A-Fa-f]{1,4}:){1}(((:[0-9A-Fa-f]{1,4}){1,6})|((:[0-9A-Fa-f]{1,4}){0,4}:((25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3}))|:))|(:(((:[0-9A-Fa-f]{1,4}){1,7})|((:[0-9A-Fa-f]{1,4}){0,5}:((25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3}))|:)))(%.+)?\s*$/ =~ addr
+    false
+  end
+
+  #
+  # Checks if the argument is a valid IPv6 reverse address
+  # expressed in arpa format.
+  #
+  #   IPAddress.valid_ipv6_reverse? "2.0.0.0.5.0.5.0.e.f.f.3.ip6.arpa"
+  #     #=> true
+  #
+  def self.valid_ipv6_reverse?(addr)
+    IPAddress::IPv6.from_reverse(addr)
+    true
+  rescue
     false
   end
 

--- a/lib/ipaddress/ipv4.rb
+++ b/lib/ipaddress/ipv4.rb
@@ -599,6 +599,39 @@ module IPAddress;
     alias_method :arpa, :reverse
     
     #
+    # Returns the IP network in in-addr.arpa format
+    # for DNS lookups
+    #
+    #   ip = IPAddress("172.16.100.50/24")
+    #
+    #   ip.reverse_network
+    #     #=> "100.16.172.in-addr.arpa"
+    #
+    # Returns nil if the prefix is not a power of 8
+    #
+    def reverse_network
+      return if (prefix == 0) || (prefix.to_i % 8) > 0
+      length = prefix.to_i / 8
+      @octets.first(length).reverse.join(".") + ".in-addr.arpa"
+    end
+    alias_method :arpa_network, :reverse_network
+
+    #
+    # Returns the IP address from the in-addr.arpa format
+    #
+    #   IPAddress::IPv4.from_reverse("100.16.172.in-addr.arpa").to_string
+    #   #=> "172.16.15.0/24"
+    #
+    def self.from_reverse(reverse)
+      address = reverse.gsub(/^(.*)\.in-addr.arpa$/, '\1').split('.').reverse
+      prefix = address.count * 8
+      address = address.fill("0", address.length...4).join('.')
+      new("#{address}/#{prefix}")
+    rescue ArgumentError
+      raise ArgumentError, "Invalid reverse IP #{reverse.inspect}"
+    end
+
+    #
     # Splits a network into different subnets
     #
     # If the IP Address is a network, it can be divided into

--- a/test/ipaddress/ipv4_test.rb
+++ b/test/ipaddress/ipv4_test.rb
@@ -320,6 +320,18 @@ class IPv4Test < Minitest::Test
     assert_equal "1.10.16.172.in-addr.arpa", @ip.reverse
   end
   
+  def test_method_reverse_network
+    assert_equal "10.16.172.in-addr.arpa", @ip.reverse_network
+    assert_nil @klass.new("172.16.10.1/25").reverse_network
+  end
+  
+  def test_method_from_reverse
+    reverse = "10.16.172.in-addr.arpa"
+    invalid_reverse = ".16.172.in-addr.arpa"
+    assert_equal @network, @klass.from_reverse(reverse)
+    assert_raises(ArgumentError) {@klass.from_reverse(invalid_reverse)}
+  end
+  
   def test_method_compare
     ip1 = @klass.new("10.1.1.1/8")
     ip2 = @klass.new("10.1.1.1/16")

--- a/test/ipaddress/ipv6_test.rb
+++ b/test/ipaddress/ipv6_test.rb
@@ -192,6 +192,19 @@ class IPv6Test < Minitest::Test
     assert_equal str, @klass.new("3ffe:505:2::f").reverse
   end
 
+  def test_method_reverse_network
+    str = "2.0.0.0.5.0.5.0.e.f.f.3.ip6.arpa"
+    assert_equal str, @klass.new("3ffe:505:2::f/48").reverse_network
+    assert_nil @klass.new("3ffe:505:2::f/49").reverse_network
+  end
+
+  def test_method_from_reverse
+    reverse = "2.0.0.0.5.0.5.0.e.f.f.3.ip6.arpa"
+    invalid_reverse = ".0.0.0.5.0.5.0.e.f.f.3.ip6.arpa"
+    assert_equal @klass.new("3ffe:505:2::/48"), @klass.from_reverse(reverse)
+    assert_raises(ArgumentError) {@klass.from_reverse(invalid_reverse)}
+  end
+
   def test_method_compressed
     assert_equal "1:1:1::1", @klass.new("1:1:1:0:0:0:0:1").compressed
     assert_equal "1:0:1::1", @klass.new("1:0:1:0:0:0:0:1").compressed

--- a/test/ipaddress_test.rb
+++ b/test/ipaddress_test.rb
@@ -6,10 +6,14 @@ class IPAddressTest < Minitest::Test
     @valid_ipv4   = "172.16.10.1/24"
     @valid_ipv6   = "2001:db8::8:800:200c:417a/64"
     @valid_mapped = "::13.1.68.3"
+    @valid_ipv4_reverse = "10.16.172.in-addr.arpa"
+    @valid_ipv6_reverse = "2.0.0.0.5.0.5.0.e.f.f.3.ip6.arpa"
 
     @invalid_ipv4   = "10.0.0.256"
     @invalid_ipv6   = ":1:2:3:4:5:6:7"
     @invalid_mapped = "::1:2.3.4"
+    @invalid_ipv4_reverse = ".16.172.in-addr.arpa"
+    @invalid_ipv6_reverse = ".0.0.0.5.0.5.0.e.f.f.3.ip6.arpa"
 
     @valid_ipv4_uint32 = [4294967295, # 255.255.255.255
                           167772160,  # 10.0.0.0
@@ -42,10 +46,14 @@ class IPAddressTest < Minitest::Test
     assert_instance_of @ipv4class, @method.call(@valid_ipv4) 
     assert_instance_of @ipv6class, @method.call(@valid_ipv6) 
     assert_instance_of @mappedclass, @method.call(@valid_mapped)
+    assert_instance_of @ipv4class, @method.call(@valid_ipv4_reverse) 
+    assert_instance_of @ipv6class, @method.call(@valid_ipv6_reverse) 
 
     assert_raises(ArgumentError) {@method.call(@invalid_ipv4)}
     assert_raises(ArgumentError) {@method.call(@invalid_ipv6)}
     assert_raises(ArgumentError) {@method.call(@invalid_mapped)}
+    assert_raises(ArgumentError) {@method.call(@invalid_ipv4_reverse)}
+    assert_raises(ArgumentError) {@method.call(@invalid_ipv6_reverse)}
 
     assert_instance_of @ipv4class, @method.call(@valid_ipv4_uint32[0]) 
     assert_instance_of @ipv4class, @method.call(@valid_ipv4_uint32[1]) 
@@ -75,6 +83,16 @@ class IPAddressTest < Minitest::Test
   def test_module_method_valid_ipv4_netmark?
     assert_equal true, IPAddress::valid_ipv4_netmask?("255.255.255.0")
     assert_equal false, IPAddress::valid_ipv4_netmask?("10.0.0.1")
+  end
+
+  def test_module_method_valid_ipv4_reverse?
+    assert_equal true, IPAddress::valid_ipv4_reverse?("10.16.172.in-addr.arpa")
+    assert_equal false, IPAddress::valid_ipv4_reverse?(".16.172.in-addr.arpa")
+  end
+
+  def test_module_method_valid_ipv6_reverse?
+    assert_equal true, IPAddress::valid_ipv6_reverse?("2.0.0.0.5.0.5.0.e.f.f.3.ip6.arpa")
+    assert_equal false, IPAddress::valid_ipv6_reverse?(".0.0.0.5.0.5.0.e.f.f.3.ip6.arpa")
   end
 
 end


### PR DESCRIPTION
Allows IPv6 reversing, network reversing (through `#reverse_network`, for arpa classes handling) and v4/v6 arpa strings to `IPAddress` conversion.

Added `IPAddress#parse` the ability to handle arpa strings and return corresponding network addresses.

I thought about handling arpa strings in `#new` but I prefered keeping this feature into `#from_reverse` methods.

Added `#valid_ipv4_reverse?` and `#valid_ipv6_reverse?` to check those strings.

I think reverse handling is quite complete now...