### PR TITLE
add minitest to development group in Gemfile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ server.rb
 *.sw?
 /tmp/
 /_yardoc/
+.idea/

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,7 @@
 source "https://rubygems.org"
 
 gemspec
+
+group :development do
+  gem 'minitest', '~> 5.8', '>= 5.8.4'
+end


### PR DESCRIPTION
Was getting this:

```
fx-mbp-13:bluemonk_ipaddress fluong$ rake test
/Users/fluong/.rvm/rubies/ruby-2.2.1/bin/ruby --verbose -w -I"lib:lib:test" -I"/Users/fluong/.rvm/gems/ruby-2.2.1/gems/rake-11.1.0/lib" "/Users/fluong/.rvm/gems/ruby-2.2.1/gems/rake-11.1.0/lib/rake/rake_test_loader.rb" "test/**/*_test.rb" 
/Users/fluong/github/bluemonk_ipaddress/test/test_helper.rb:2:in `require': cannot load such file -- minitest/autorun (LoadError)
        from /Users/fluong/github/bluemonk_ipaddress/test/test_helper.rb:2:in `<top (required)>'
        from /Users/fluong/github/bluemonk_ipaddress/test/ipaddress/ipv4_test.rb:1:in `require'
        from /Users/fluong/github/bluemonk_ipaddress/test/ipaddress/ipv4_test.rb:1:in `<top (required)>'
        from /Users/fluong/.rvm/gems/ruby-2.2.1/gems/rake-11.1.0/lib/rake/rake_test_loader.rb:10:in `require'
        from /Users/fluong/.rvm/gems/ruby-2.2.1/gems/rake-11.1.0/lib/rake/rake_test_loader.rb:10:in `block (2 levels) in <main>'
        from /Users/fluong/.rvm/gems/ruby-2.2.1/gems/rake-11.1.0/lib/rake/rake_test_loader.rb:9:in `each'
        from /Users/fluong/.rvm/gems/ruby-2.2.1/gems/rake-11.1.0/lib/rake/rake_test_loader.rb:9:in `block in <main>'
        from /Users/fluong/.rvm/gems/ruby-2.2.1/gems/rake-11.1.0/lib/rake/rake_test_loader.rb:4:in `select'
        from /Users/fluong/.rvm/gems/ruby-2.2.1/gems/rake-11.1.0/lib/rake/rake_test_loader.rb:4:in `<main>'
rake aborted!
Command failed with status (1): [ruby --verbose -w -I"lib:lib:test" -I"/Users/fluong/.rvm/gems/ruby-2.2.1/gems/rake-11.1.0/lib" "/Users/fluong/.rvm/gems/ruby-2.2.1/gems/rake-11.1.0/lib/rake/rake_test_loader.rb" "test/**/*_test.rb" ]
/Users/fluong/.rvm/gems/ruby-2.2.1/bin/ruby_executable_hooks:15:in `eval'
/Users/fluong/.rvm/gems/ruby-2.2.1/bin/ruby_executable_hooks:15:in `<main>'
Tasks: TOP => test
(See full trace by running task with --trace)
```

But now it works.